### PR TITLE
fix positive arity check

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -104,7 +104,7 @@ func protocolHandler(c *client) {
 		}
 
 		// check command arity, negative arity means >= n
-		if (command.arity < 0 && len(args)-1 < -command.arity) || (command.arity >= 0 && len(args)-1 > command.arity) {
+		if (command.arity < 0 && len(args)-1 < -command.arity) || (command.arity >= 0 && len(args)-1 < command.arity) {
 			writeError(c.w, "wrong number of arguments for '"+string(args[0])+"' command")
 			return
 		}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -22,6 +22,46 @@ func (s ProtocolSuite) TestPing(c *C) {
 	c.Assert(res, DeepEquals, []byte("+PONG\r\n"))
 }
 
+func (s ProtocolSuite) TestArity(c *C) {
+	a, b := net.Pipe()
+	defer a.Close()
+	go handleClient(b)
+
+	tests := []struct {
+		cmd      string
+		expected string
+	}{
+		// invalid positive arity
+		{
+			"*1\r\n$6\r\nLRANGE\r\n",
+			"-ERR wrong number of arguments for 'LRANGE' command\r\n",
+		},
+		// valid positive arity
+		{
+			"*4\r\n$6\r\nLRANGE\r\n$3\r\nfoo\r\n$1\r\n0\r\n$2\r\n-1\r\n",
+			"*0\r\n",
+		},
+		// invalid negative arity
+		{
+			"*1\r\n$5\r\nLPUSH\r\n",
+			"-ERR wrong number of arguments for 'LPUSH' command\r\n",
+		},
+		// valid negative arity
+		{
+			"*3\r\n$5\r\nLPUSH\r\n$3\r\nfoo\r\n$1\r\nA\r\n",
+			":1\r\n",
+		},
+	}
+
+	var res []byte
+	for _, t := range tests {
+		a.Write([]byte(t.cmd))
+		res = make([]byte, len(t.expected))
+		a.Read(res)
+		c.Assert(res, DeepEquals, []byte(t.expected))
+	}
+}
+
 func BenchmarkProtocolParserSimple(b *testing.B) {
 	b.StopTimer()
 	client, server := net.Pipe()


### PR DESCRIPTION
Positive arity check was wrong. Setdb would crash from redis-cli by running simple `lrange`
